### PR TITLE
Add documentation READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# PDFTools – OCR et Compression
+
+## A PROPOS / OBJECTIFS
+Application permettant l’OCR et la compression de fichiers PDF via une API FastAPI couplée à un worker Celery. Les scripts de déploiement fournissent une installation clef en main sur un serveur Linux.
+
+## SCOPE
+Destiné aux développeurs et administrateurs système souhaitant déployer ou contribuer à l’outil.
+
+## PRÉREQUIS
+- Système Linux avec `python3`, `pip`, `redis-server`, `git` et `apache2`.
+- Droits sudo pour l’installation des paquets et des services systemd.
+
+## ORGANISATION DU PROJET
+- `backend/` : API FastAPI et worker Celery.
+- `frontend/` : pages statiques de téléversement des PDF.
+- `deploy/` : scripts shell et fichiers de configuration pour installer l’application (packages APT, services systemd, Apache).
+- `requirements/` : listes de dépendances Python.
+- `Global_manage_pdftools.sh` et `install_all.sh` : scripts globaux d’installation et de gestion du projet.
+
+## INSTALLATION RAPIDE
+1. Cloner le dépôt puis se placer à la racine.
+2. Exécuter `sudo bash install_all.sh` pour une installation guidée (environnement, dépendances, services, Apache).
+3. Utiliser `sudo bash Global_manage_pdftools.sh` pour gérer les services (démarrage, logs, purge, etc.).
+
+## CONTRIBUTION
+- Fork du projet puis création de branches thématiques.
+- Respecter la structure existante et fournir des tests unitaires pour chaque nouvelle fonctionnalité.
+- Les scripts de déploiement nécessitent un shell POSIX et peuvent être adaptés pour votre distribution.
+
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,28 @@
+# backend
+
+## A PROPOS / OBJECTIFS
+Implémente l’API FastAPI ainsi que le worker Celery pour l’OCR et la compression de PDF.
+
+## SCOPE
+Utilisé par les développeurs backend et par les administrateurs lors du déploiement.
+
+## PRÉREQUIS
+- Python 3.11 ou plus
+- Redis en service pour Celery
+
+## CONTENU DU DOSSIER
+- `app/` : code de l’application (routes, services, utils).
+- `scripts/` : utilitaires administratifs (purge des anciens jobs).
+- `tests/` : tests unitaires.
+- `worker/` : définition des tâches Celery.
+- `logs/` : destination des logs d’exécution.
+
+## INSTRUCTIONS PRINCIPALES
+- Lancer l’API : `uvicorn app.main:app --reload` depuis ce dossier (appli dev).
+- Exécuter un worker : `celery -A worker.tasks worker --loglevel=INFO`.
+- Purger les anciens jobs : `python scripts/purge_old_jobs.py`.
+
+## NOTES
+Les chemins des dossiers (données, frontend) sont configurés dans `app/config.py`. Adapter la variable `CELERY_BROKER_URL` si Redis n’est pas local.
+
+

--- a/backend/app/README.md
+++ b/backend/app/README.md
@@ -1,0 +1,28 @@
+# backend/app
+
+## A PROPOS / OBJECTIFS
+Cœur de l’application FastAPI : configuration, routes API, services et utilitaires.
+
+## SCOPE
+Développeurs Python souhaitant modifier l’API ou les traitements OCR.
+
+## PRÉREQUIS
+- Activation de l’environnement virtuel Python
+- Variables d’environnement dans `.env` si nécessaire
+
+## CONTENU DU DOSSIER
+- `main.py` : point d’entrée FastAPI.
+- `config.py` : paramètres généraux (chemins, ports, Redis).
+- `api/` : routes HTTP (upload, statut, téléchargement).
+- `services/` : logique métier, notamment `ocr_service.py`.
+- `utils/` : fonctions d’aide (génération d’ID, sécurisation de noms de fichiers).
+- `models/` : modèles Pydantic pour la réponse API.
+- `logger.py` : configuration Loguru.
+
+## INSTRUCTIONS PRINCIPALES
+Lancer directement `uvicorn app.main:app` pour exposer l’API. Les chemins par défaut pointent vers `../data/jobs` pour stocker les traitements.
+
+## NOTES
+Les fichiers de log sont écrits dans `../logs/ocr.log`. Veiller à créer ce dossier avec les droits adéquats.
+
+

--- a/backend/app/api/README.md
+++ b/backend/app/api/README.md
@@ -1,0 +1,24 @@
+# backend/app/api
+
+## A PROPOS / OBJECTIFS
+Expose les endpoints FastAPI permettant de téléverser des PDF, suivre le statut et récupérer les fichiers traités.
+
+## SCOPE
+Développeurs ou intégrateurs d’API.
+
+## PRÉREQUIS
+Avoir l’application à la racine du projet et l’environnement Python préparé.
+
+## CONTENU DU DOSSIER
+- `upload.py` : enregistrement des fichiers et lancement de la tâche Celery.
+- `status.py` : consultation de l’état d’un job.
+- `download.py` : récupération des fichiers compressés.
+- `__init__.py` : définition du router principal.
+
+## INSTRUCTIONS PRINCIPALES
+Les routes sont incluses via `app.include_router` dans `main.py`. Chaque route retourne des modèles Pydantic définis dans `../models`.
+
+## NOTES
+Vérifier les droits d’écriture sur le dossier `data/jobs` pour que l’upload fonctionne.
+
+

--- a/backend/app/services/ocr/README.md
+++ b/backend/app/services/ocr/README.md
@@ -1,0 +1,23 @@
+# backend/app/services/ocr
+
+## A PROPOS / OBJECTIFS
+Composants réalisant l’OCR et la compression des PDF.
+
+## SCOPE
+Développeurs souhaitant ajuster le traitement des fichiers.
+
+## PRÉREQUIS
+- `ocrmypdf` et `pikepdf` présents dans l’environnement Python.
+- Accès à `tesseract-ocr` via les packages APT.
+
+## CONTENU DU DOSSIER
+- `ocr_service.py` : classe principale assurant l’analyse des PDF et la génération des résultats.
+- `__init__.py` : init du module.
+
+## INSTRUCTIONS PRINCIPALES
+Instancier `OCRService(job_id)` puis appeler `process()` pour lancer le traitement. Les fichiers d’entrée/sortie se trouvent dans `data/jobs/<job_id>/`.
+
+## NOTES
+Le service gère la détection des erreurs courantes : PDF protégé par mot de passe, taille trop importante, signatures numériques, etc.
+
+

--- a/backend/app/utils/README.md
+++ b/backend/app/utils/README.md
@@ -1,0 +1,23 @@
+# backend/app/utils
+
+## A PROPOS / OBJECTIFS
+Fonctions utilitaires utilisées par l’API et le worker.
+
+## SCOPE
+Développeurs Python.
+
+## PRÉREQUIS
+Aucun en dehors des dépendances Python de base du projet.
+
+## CONTENU DU DOSSIER
+- `filename_utils.py` : nettoyage et sécurisation des noms de fichiers uploadés.
+- `id_generator.py` : création d’identifiants de jobs horodatés.
+- `__init__.py` : expose les fonctions du module.
+
+## INSTRUCTIONS PRINCIPALES
+Importer les fonctions depuis `app.utils` pour garantir une résolution correcte des modules.
+
+## NOTES
+Le nettoyage de nom de fichier suit la convention ASCII et remplace les caractères non sûrs.
+
+

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,22 @@
+# backend/scripts
+
+## A PROPOS / OBJECTIFS
+Scripts Python utilitaires liés à la maintenance des jobs OCR.
+
+## SCOPE
+Admins système souhaitant nettoyer régulièrement les répertoires de travail.
+
+## PRÉREQUIS
+- Exécution depuis l’environnement Python du projet.
+
+## CONTENU DU DOSSIER
+- `purge_old_jobs.py` : supprime les jobs dont la durée de vie a expiré (paramètre `JOB_TTL_SECONDS`).
+- `__init__.py` : fichier vide.
+
+## INSTRUCTIONS PRINCIPALES
+`python purge_old_jobs.py` supprime les dossiers de jobs terminés au-delà de la durée configurée.
+
+## NOTES
+Peut être appelé automatiquement via le timer systemd `purge-ocr.timer`.
+
+

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,0 +1,22 @@
+# backend/tests
+
+## A PROPOS / OBJECTIFS
+Jeux de tests unitaires pour valider les fonctions utilitaires.
+
+## SCOPE
+Développeurs souhaitant contribuer au backend.
+
+## PRÉREQUIS
+- PyTest installé
+
+## CONTENU DU DOSSIER
+- `test_secure_filename.py` : vérifie la fonction `secure_filename`.
+- `__init__.py` : initialise le paquet de tests.
+
+## INSTRUCTIONS PRINCIPALES
+Lancer `pytest` depuis la racine `backend/` ou `backend/tests/`.
+
+## NOTES
+Les tests utilisent Python `sys.path` pour inclure le dossier parent.
+
+

--- a/backend/worker/README.md
+++ b/backend/worker/README.md
@@ -1,0 +1,23 @@
+# backend/worker
+
+## A PROPOS / OBJECTIFS
+Contient la configuration Celery pour exécuter les tâches d’OCR en arrière-plan.
+
+## SCOPE
+Admins ou développeurs déployant le worker.
+
+## PRÉREQUIS
+- Redis lancé et accessible
+- Environnement Python avec les packages de `requirements/base.txt`
+
+## CONTENU DU DOSSIER
+- `tasks.py` : déclaration des tâches Celery et logique de gestion d’état.
+- `__init__.py` : charge Celery.
+
+## INSTRUCTIONS PRINCIPALES
+Lancer `celery -A worker.tasks worker --loglevel=INFO` depuis `backend/`. Les variables broker/backends sont dans `app/config.py`.
+
+## NOTES
+Les logs des tâches sont redirigés via Loguru dans `backend/logs/ocr.log`.
+
+

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,26 @@
+# deploy
+
+## A PROPOS / OBJECTIFS
+Scripts et configurations pour installer PDFTools sur un serveur Linux (packages, services systemd, Apache).
+
+## SCOPE
+Administrateurs système.
+
+## PRÉREQUIS
+- Accès root ou sudo
+- Distribution Debian/Ubuntu conseillée
+
+## CONTENU DU DOSSIER
+- `apt/` : listes de paquets à installer.
+- `scripts/` : scripts d’installation et de désinstallation.
+- `apache/` : fichier de configuration du virtual host Apache.
+- `systemd/` : unités de services et timer.
+- `environments/` : exemples de fichiers `.env`.
+
+## INSTRUCTIONS PRINCIPALES
+Exécuter `sudo bash install_all.sh` à la racine pour une installation complète ou lancer les scripts de ce dossier individuellement.
+
+## NOTES
+Les chemins cibles `/etc/systemd/system` et `/etc/apache2` sont codés dans les scripts. Adapter si besoin.
+
+

--- a/deploy/apache/README.md
+++ b/deploy/apache/README.md
@@ -1,0 +1,22 @@
+# deploy/apache
+
+## A PROPOS / OBJECTIFS
+Configuration Apache pour servir le frontend statique et proxyfier les requêtes API vers FastAPI.
+
+## SCOPE
+Admins système utilisant Apache comme reverse proxy.
+
+## PRÉREQUIS
+- Apache2 installé
+- Droits sudo pour modifier `/etc/apache2`
+
+## CONTENU DU DOSSIER
+- `pdftools.conf` : virtual host à déployer dans `/etc/apache2/sites-available/`.
+
+## INSTRUCTIONS PRINCIPALES
+Activer le site via `a2ensite pdftools.conf` puis recharger Apache. Le script `deploy/scripts/04_apache.sh` réalise ces étapes automatiquement.
+
+## NOTES
+Le virtual host pointe sur `frontend/` pour le contenu statique et redirige `/api` vers le backend sur localhost.
+
+

--- a/deploy/apt/README.md
+++ b/deploy/apt/README.md
@@ -1,0 +1,23 @@
+# deploy/apt
+
+## A PROPOS / OBJECTIFS
+Listes de paquets APT nécessaires au fonctionnement de l’application (Python, OCR, PDF, outils divers).
+
+## SCOPE
+Administrateurs lors de l’installation sur Debian/Ubuntu.
+
+## PRÉREQUIS
+Avoir `apt` et les droits sudo.
+
+## CONTENU DU DOSSIER
+- `base.txt` : paquets de base (python3, redis, libs de compilation, etc.).
+- `ocr.txt` : paquets spécifiques à la reconnaissance de texte (tesseract, libjpeg...).
+- `pdf.txt` : outils supplémentaires pour la manipulation des PDF.
+
+## INSTRUCTIONS PRINCIPALES
+Utilisé par `deploy/scripts/01_apt.sh`. Les paquets peuvent être installés manuellement via `sudo xargs -a <fichier> apt install -y`.
+
+## NOTES
+Adapter les fichiers selon la distribution cible si certains packages sont absents.
+
+

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -1,0 +1,28 @@
+# deploy/scripts
+
+## A PROPOS / OBJECTIFS
+Contient les scripts shell d’installation et de maintenance (APT, Python, systemd, Apache).
+
+## SCOPE
+Admins souhaitant automatiser le déploiement de PDFTools.
+
+## PRÉREQUIS
+- Shell POSIX
+- Droits sudo
+
+## CONTENU DU DOSSIER
+- `00_select_env.sh` : choix de l’environnement (dev ou prod) et génération du fichier `.env`.
+- `01_apt.sh` : installation des paquets listés dans `../apt`.
+- `02_python.sh` : mise en place de la venv Python et installation des requirements.
+- `03_systemd.sh` : déploiement des unités systemd.
+- `04_apache.sh` : configuration du virtual host Apache.
+- `05_uninstall_systemd.sh` : suppression des services.
+- `06_uninstall_apache.sh` : désactivation du site Apache.
+
+## INSTRUCTIONS PRINCIPALES
+Les scripts sont pensés pour être exécutés depuis `install_all.sh`. Ils peuvent toutefois être lancés individuellement avec `sudo bash <script>`.
+
+## NOTES
+Certains scripts redémarrent les services. Prévoir un accès root et vérifier le contenu du fichier `.env` avant d’exécuter.
+
+

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,24 @@
+# deploy/systemd
+
+## A PROPOS / OBJECTIFS
+Unités systemd permettant de lancer le backend FastAPI, le worker Celery et la purge périodique.
+
+## SCOPE
+Administrateurs système.
+
+## PRÉREQUIS
+- Sudo et accès à `/etc/systemd/system`
+
+## CONTENU DU DOSSIER
+- `ocr-api.service` : lance l’API FastAPI via Uvicorn.
+- `celery-ocr.service` : worker Celery pour le traitement des PDF.
+- `purge-ocr.service` : exécute la purge manuelle.
+- `purge-ocr.timer` : planifie la purge toutes les 30 minutes.
+
+## INSTRUCTIONS PRINCIPALES
+Copier ces fichiers dans `/etc/systemd/system` puis exécuter `systemctl daemon-reload`. Utiliser `enable --now` pour activer chaque service. Le script `deploy/scripts/03_systemd.sh` automatise cette opération.
+
+## NOTES
+Adapter les chemins dans les unités si le projet n’est pas installé dans `/opt/pdftools`.
+
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,24 @@
+# frontend
+
+## A PROPOS / OBJECTIFS
+Pages HTML/CSS/JS pour permettre le téléversement des PDF et afficher l’avancement.
+
+## SCOPE
+Développeurs frontend ou intégrateurs.
+
+## PRÉREQUIS
+Nécessite uniquement un navigateur moderne. Aucune compilation n’est requise.
+
+## CONTENU DU DOSSIER
+- `index.html` : page d’accueil.
+- `compress.html` : interface de téléversement.
+- `assets/` : feuilles de style et scripts JavaScript.
+- `img/` : images du site.
+
+## INSTRUCTIONS PRINCIPALES
+Ces fichiers peuvent être servis en statique par Apache ou via FastAPI. Les appels à l’API se font sur `/api`.
+
+## NOTES
+Vérifier la cohérence des URLs de l’API en fonction du reverse proxy utilisé.
+
+

--- a/frontend/assets/README.md
+++ b/frontend/assets/README.md
@@ -1,0 +1,22 @@
+# frontend/assets
+
+## A PROPOS / OBJECTIFS
+Ressources statiques pour l’interface web.
+
+## SCOPE
+Intégrateurs web.
+
+## PRÉREQUIS
+Aucun.
+
+## CONTENU DU DOSSIER
+- `css/` : feuilles de style pour les pages HTML.
+- `js/` : scripts gérant l’upload et la traduction.
+
+## INSTRUCTIONS PRINCIPALES
+Modifier ces fichiers pour personnaliser l’interface. Les chemins sont relatifs aux pages HTML.
+
+## NOTES
+Les scripts s’attendent à ce que l’API soit accessible sous `/api`.
+
+

--- a/frontend/assets/css/README.md
+++ b/frontend/assets/css/README.md
@@ -1,0 +1,22 @@
+# frontend/assets/css
+
+## A PROPOS / OBJECTIFS
+Feuilles de style pour l’interface web.
+
+## SCOPE
+Intégrateurs et développeurs frontend.
+
+## PRÉREQUIS
+Aucun.
+
+## CONTENU DU DOSSIER
+- `style.css` : style général de l’application.
+- `dashboard.css` : mise en forme spécifique au tableau de résultats.
+
+## INSTRUCTIONS PRINCIPALES
+Inclure ces CSS dans les pages HTML via un chemin relatif `./assets/css/`.
+
+## NOTES
+Ajuster les classes selon la charte graphique souhaitée.
+
+

--- a/frontend/assets/js/README.md
+++ b/frontend/assets/js/README.md
@@ -1,0 +1,22 @@
+# frontend/assets/js
+
+## A PROPOS / OBJECTIFS
+Scripts JavaScript gérant l’upload de fichiers et la traduction de l’interface.
+
+## SCOPE
+Développeurs front-end.
+
+## PRÉREQUIS
+Aucun.
+
+## CONTENU DU DOSSIER
+- `compress.js` : logique d’upload et suivi de progression.
+- `lang.js` : dictionnaire FR/EN pour l’interface.
+
+## INSTRUCTIONS PRINCIPALES
+Les scripts sont inclus dans `compress.html`. Adapter `API_BASE` dans `compress.js` si l’URL de l’API change.
+
+## NOTES
+Le code est vanilla JS sans framework.
+
+

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,0 +1,23 @@
+# requirements
+
+## A PROPOS / OBJECTIFS
+Fichiers listant les dépendances Python du projet.
+
+## SCOPE
+Développeurs et administrateurs installant l’environnement.
+
+## PRÉREQUIS
+Python 3.11 et `pip`.
+
+## CONTENU DU DOSSIER
+- `base.txt` : dépendances communes à tous les environnements.
+- `dev.txt` : packages additionnels pour le développement et les tests.
+- `prod.txt` : référence vers `base.txt` (minimal en production).
+
+## INSTRUCTIONS PRINCIPALES
+Depuis la racine, `python -m venv venv && source venv/bin/activate` puis `pip install -r requirements/dev.txt` pour un environnement complet.
+
+## NOTES
+Les scripts d’installation utilisent ces fichiers pour configurer la venv automatiquement.
+
+


### PR DESCRIPTION
## Summary
- add README with project overview
- document backend and worker folders
- document deployment scripts and configs
- add frontend and requirements READMEs

## Testing
- `pytest backend/tests/test_secure_filename.py -q`
